### PR TITLE
Design: Header .header__title의 after요소 design 변경

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -18,18 +18,9 @@
   position: absolute;
   bottom: 6px;
   left: -5%;
-  transform: scaleX(0);
   background: #309cff;
   z-index: -1;
-  transition: transform 0.3s;
-  transform-origin: 0 0;
-  transition-timing-function: ease-out;
 }
-
-.header__title:hover::after {
-transform: scaleX(1);
-}
-
 
 .header__subtitle {
   font-size: 2.6rem;


### PR DESCRIPTION
Header 컴포넌트의 .header__title:after요소의 hover효과를 제거하여 hover 했을 때의 모습이 항상 보이도록 수정