### PR TITLE
Fix: Todo modal에서 입력 시 커서 초기화 문제를 useRef로 해결

### DIFF
--- a/src/components/TodoModal/TodoModal.jsx
+++ b/src/components/TodoModal/TodoModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import './TodoModal.css';
 import Button from '../Button/Button';
 import { BsCheckLg, BsTrash } from 'react-icons/bs';
@@ -8,14 +8,42 @@ import { RiArrowGoBackLine } from 'react-icons/ri';
 import IconButton from '../IconButton/IconButton';
 
 const TodoModal = ({ editTodo ,endEditTodo,updateEditTodoTitle,updateEditTodoBody,deleteTodo,updateEditTodoIsDone }) => {
+  const selectionRef = useRef(null)
 
   const handleInputTitle = (e) => {
+    const { anchorNode,anchorOffset } = window.getSelection()
+    setSelectionRef(anchorNode,anchorOffset)
     updateEditTodoTitle(e.target.innerText)
   }
 
   const handleInputBody = (e) => {
+    const { anchorNode,anchorOffset } = window.getSelection()
+    setSelectionRef(anchorNode,anchorOffset)
     updateEditTodoBody(e.target.innerText)
   }
+
+  const setSelectionRef = (anchorNode, anchorOffset) => {
+    selectionRef.current = { anchorNode, anchorOffset}
+  }
+
+  const getSelectionRef = () => {
+    return selectionRef.current
+  }
+
+  const clearSelectionRef = () => {
+    selectionRef.current = null
+  }
+
+  const handleBlur = () => {
+    clearSelectionRef()
+  }
+
+  useEffect(() => {
+    if(selectionRef.current) {
+      const { anchorNode, anchorOffset } = getSelectionRef()
+      window.getSelection().collapse(anchorNode, anchorOffset)
+    }
+  })
 
   return (
     <div className='todoModal__container'>
@@ -36,6 +64,7 @@ const TodoModal = ({ editTodo ,endEditTodo,updateEditTodoTitle,updateEditTodoBod
               contentEditable='true' 
               suppressContentEditableWarning={true} 
               onInput={handleInputTitle}
+              onBlur={handleBlur}
             >
               {editTodo.title}
             </h5>
@@ -44,6 +73,7 @@ const TodoModal = ({ editTodo ,endEditTodo,updateEditTodoTitle,updateEditTodoBod
               contentEditable='true' 
               suppressContentEditableWarning={true} 
               onInput={handleInputBody}
+              onBlur={handleBlur}
             >
             {editTodo.body}
             </p>


### PR DESCRIPTION
contentEditable 속성을 가진 입력 가능한
todoModal__title, todoModal__content에 대해
입력할 때 커서가 초기화되는 문제를 해결하기
위해 useRef로 커서 위치를 기억